### PR TITLE
Fix repos sort_by NaiveDateTime type

### DIFF
--- a/apps/gitgud_web/lib/gitgud_web/templates/repo/index.html.eex
+++ b/apps/gitgud_web/lib/gitgud_web/templates/repo/index.html.eex
@@ -26,7 +26,7 @@
     <% end %>
   </article>
 <% else %>
-  <%= for repo <- Enum.sort_by(@user.repos, &(&1.pushed_at), :desc) do %>
+  <%= for repo <- Enum.sort_by(@user.repos, &(&1.pushed_at), {:desc, NaiveDateTime}) do %>
     <div class="columns">
       <div class="column is-full">
         <div class="repo card">


### PR DESCRIPTION
According to https://hexdocs.pm/elixir/Enum.html#sort_by/3-ascending-and-descending-since-v1-10-0

As in [sort/2](https://hexdocs.pm/elixir/Enum.html#sort/2), avoid using the default sorting function to sort structs, as by default it performs structural comparison instead of a semantic one.

