### PR TITLE
Fix nil edge condition for initial commit diff preview.

### DIFF
--- a/apps/gitrekt/lib/gitrekt/git_agent.ex
+++ b/apps/gitrekt/lib/gitrekt/git_agent.ex
@@ -1224,6 +1224,10 @@ defmodule GitRekt.GitAgent do
     end
   end
 
+  defp fetch_tree(nil, _handle) do
+    {:ok, %GitTree{oid: <<0::160>>, __ref__: nil}}
+  end
+
   defp fetch_tree(%GitCommit{__ref__: commit}, _handle) do
     case Git.commit_tree(commit) do
       {:ok, oid, tree} ->


### PR DESCRIPTION
When accessing the diff page of a repository's initial commit, a service exception occurs because old_tree is nil.

Replication link: https://git.limo/edmondfrank/Test/commit/9b8aaf04f53429bba6b203dcafafca031b46e164